### PR TITLE
Use a printer_trait concept instead of std::function

### DIFF
--- a/include/logfmtxx.hpp
+++ b/include/logfmtxx.hpp
@@ -81,11 +81,14 @@ namespace logfmtxx {
     T value;
   };
 
-  template <typename clock_type = std::chrono::system_clock>
-  class logger {
-    public:
-      using printer_type = std::function<void(const std::string&)>;
+  template <typename T>
+  concept printer_trait = requires(T t, const std::string &msg) {
+    { t(msg) };
+  };
 
+  template <typename clock_type = std::chrono::system_clock,
+            printer_trait printer_type = std::function<void(const std::string&)>>
+  class logger {
     public:
       template <typename... Args>
       logger(


### PR DESCRIPTION
This will allow logger to work without a std::function.

E.g., you can create a logger from a function pointer or lambda without creating a std::function object.

```c++
logfmtxx::logger logger{[](const std::string& msg) { std::cout << msg << '\n'}; // printer_type is the lambda, not std::function
// ...
void my_custom_print(const std::string& msg);
logfmtxx::logger logger2{my_custom_print}; // printer_type is a function pointer
```

I don't expect this to have much of an impact, but it might help to avoid some allocations.